### PR TITLE
Added an explicit MIT-like license crediting Diesel Horse Games.

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,10 @@
+Godot and third-party libraries are provided under their own licenses. For everything else:
+
+
+Copyright 2025 Diesel Horse Games
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the “Software”), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.


### PR DESCRIPTION
Hi Ben, thanks a lot for this example project, it's been very helpful in understanding what I need to embedded libgodot. I'd like to build off of your project for some proof-of-concept experimentation for my day job. It's a lot less headache if there's an explicit license, so I borrowed the license from https://github.com/zorbathut/dieselhorse_godot_framework. If this is okay, please accept the merge request or adjust the license to your liking. Thanks again :)